### PR TITLE
fix zram lz4kd patch issue on 5.10 oplus devices

### DIFF
--- a/other/zram/zram_patch/5.10/lz4kd.patch
+++ b/other/zram/zram_patch/5.10/lz4kd.patch
@@ -271,10 +271,10 @@ diff -u a/kernel/module.c b/kernel/module.c
 +    "lzo", "lzo_rle",
 +#endif
 +#if IS_BUILTIN(CONFIG_ZRAM)
-+    "zram",
++    "zram", "oplus_bsp_hybridswap_zram",
 +#endif
 +#if IS_BUILTIN(CONFIG_ZSMALLOC)
-+    "zsmalloc",
++    "zsmalloc", "oplus_bsp_zsmalloc",
 +#endif
 +};
 +


### PR DESCRIPTION
Since Oneplus made their own implemenatation of zram & zsmalloc, named oplus_bsp_hybridswap_zram and oplus_bsp_zsmalloc respectfully, without adding this two modules to blacklist, recovery is just refusing to load. Fix is simple: just add this two OEM variations to blacklist. Confirmed work on 5.10.226 kernel, Realme GTneo5.
Apparently, after 5.10 oplus discontinued this realisation, on 5.15 kernels and higher there are no oplus_bsp_hybridswap_zram or oplus_bsp_zsmalloc so this fix is only viable for 5.10 kernels.

This fixes any issues with SukiSu zram patches on 5.10 devices